### PR TITLE
feat: add basic Flutter TTS app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# lingo-flow
+# Lingo Flow
+
+A simple Flutter app demonstrating text-to-speech.
+It uses the [provider](https://pub.dev/packages/provider)
+and [flutter_tts](https://pub.dev/packages/flutter_tts) packages.
+
+## Getting Started
+
+This project requires the [Flutter SDK](https://docs.flutter.dev/get-started/install).
+
+1. Fetch dependencies:
+   ```bash
+   flutter pub get
+   ```
+2. Run the application:
+   ```bash
+   flutter run
+   ```

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_tts/flutter_tts.dart';
+
+void main() {
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) => TtsProvider(),
+      child: const MyApp(),
+    ),
+  );
+}
+
+class TtsProvider extends ChangeNotifier {
+  final FlutterTts _tts = FlutterTts();
+
+  Future<void> speak(String text) async {
+    await _tts.speak(text);
+  }
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Lingo Flow',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({super.key});
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Lingo Flow')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: const InputDecoration(labelText: 'Enter text'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                final text = _controller.text;
+                if (text.isNotEmpty) {
+                  context.read<TtsProvider>().speak(text);
+                }
+              },
+              child: const Text('Speak'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,20 @@
+name: lingo_flow
+description: A Flutter app showcasing text-to-speech using Provider.
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.0.5
+  flutter_tts: ^3.8.3
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- initialize minimal Flutter app scaffold with Provider and flutter_tts dependencies
- implement text-to-speech demo powered by ChangeNotifierProvider
- document setup steps in README

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b41d0381c8324bb0cbefc63417223